### PR TITLE
Remove check header dependency + include string

### DIFF
--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -27,7 +27,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <cuda.h>
-#include <check.h>
+#include <string.h>
 #include <map>
 #include <gdrapi.h>
 #include <gdrconfig.h>


### PR DESCRIPTION
If I understand correctly check lib dependency was removed several month ago, but common.hpp file still contains header inclusion. When I removed this header, I got the following errors on Ubuntu 20.04:

![image](https://github.com/ivankochin/gdrcopy/assets/22097249/5ab4ebb5-75c5-446c-a1bb-43bc3cebc7b5)

So I decided to fix two problems by one patch.